### PR TITLE
use getline instead of istream::operator>> to read the input

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -9,7 +9,7 @@ int main(int argc, char* argv[])
 {
     string action = argv[1];
     string game_state_json;
-    cin >> game_state_json;
+    std::getline(cin, game_state_json);
 
     json::Value game_state = json::Deserialize(game_state_json);
 


### PR DESCRIPTION
Just in case anybody else has the crazy idea of using C++, this patch fixes the bug in the framework that the input is only read up to the first space (first whitespace character).
